### PR TITLE
Recommended MET filters added in PatUtils.

### DIFF
--- a/data/chhiggs/xsec_samples.json
+++ b/data/chhiggs/xsec_samples.json
@@ -176,9 +176,11 @@
       "comment":"real split 17",        
       "goldenjson":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_246908-251252_13TeV_PromptReco_Collisions15_JSON.txt",
       "data":[        
-        { "dtag":"Data13TeV_SingleMuon2015B", "split":47, "xsec":1.0, "br":[ 1.0 ] , "dset":"/SingleMuon/Run2015B-PromptReco-v1/MINIAOD",       "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" },
-        { "dtag":"Data13TeV_SingleE2015B",  "split":20, "xsec":1.0, "br":[ 1.0 ] , "dset":"/SingleElectron/Run2015B-PromptReco-v1/MINIAOD", "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" },
-        { "dtag":"Data13TeV_MuonEG2015B",   "split":20, "xsec":1.0, "br":[ 1.0 ] , "dset":"/MuonEG/Run2015B-PromptReco-v1/MINIAOD",         "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" }
+        { "dtag":"Data13TeV_SingleMuon2015B", "split":47, "xsec":1.0, "br":[ 1.0 ] , "dset":"/SingleMuon/Run2015B-17Jul2015-v1/MINIAOD",       "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" },
+        { "dtag":"Data13TeV_SingleElectron2015B",  "split":20, "xsec":1.0, "br":[ 1.0 ] , "dset":"/SingleElectron/Run2015B-17Jul2015-v1/MINIAOD", "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" },
+        { "dtag":"Data13TeV_MuonEG2015B",   "split":20, "xsec":1.0, "br":[ 1.0 ] , "dset":"/MuonEG/Run2015B-17Jul2015-v1/MINIAOD",         "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" },
+        { "dtag":"Data13TeV_DoubleMuon2015B",   "split":20, "xsec":1.0, "br":[ 1.0 ] , "dset":"/DoubleMuon/Run2015B-17Jul2015-v1/MINIAOD",         "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" },
+        { "dtag":"Data13TeV_DoubleEG2015B",   "split":20, "xsec":1.0, "br":[ 1.0 ] , "dset":"/DoubleEG/Run2015B-17Jul2015-v1/MINIAOD",         "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" }
       ]             
     }    
   ]

--- a/data/chhiggs/xsec_samples.json
+++ b/data/chhiggs/xsec_samples.json
@@ -176,11 +176,13 @@
       "comment":"real split 17",        
       "goldenjson":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_246908-251252_13TeV_PromptReco_Collisions15_JSON.txt",
       "data":[        
-        { "dtag":"Data13TeV_SingleMuon2015B", "split":47, "xsec":1.0, "br":[ 1.0 ] , "dset":"/SingleMuon/Run2015B-17Jul2015-v1/MINIAOD",       "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" },
-        { "dtag":"Data13TeV_SingleElectron2015B",  "split":20, "xsec":1.0, "br":[ 1.0 ] , "dset":"/SingleElectron/Run2015B-17Jul2015-v1/MINIAOD", "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" },
-        { "dtag":"Data13TeV_MuonEG2015B",   "split":20, "xsec":1.0, "br":[ 1.0 ] , "dset":"/MuonEG/Run2015B-17Jul2015-v1/MINIAOD",         "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" },
-        { "dtag":"Data13TeV_DoubleMuon2015B",   "split":20, "xsec":1.0, "br":[ 1.0 ] , "dset":"/DoubleMuon/Run2015B-17Jul2015-v1/MINIAOD",         "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" },
-        { "dtag":"Data13TeV_DoubleEG2015B",   "split":20, "xsec":1.0, "br":[ 1.0 ] , "dset":"/DoubleEG/Run2015B-17Jul2015-v1/MINIAOD",         "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY_Run2015B.txt" }
+        { "dtag":"Data13TeV_SingleMuon2015BPromptReco", "split":50, "xsec":1.0, "br":[ 1.0 ] , "dset":"/SingleMuon/Run2015B-PromptReco-v1/MINIAOD",       "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_246908-251642_13TeV_PromptReco_Collisions15_JSON_v2.txt " },
+        { "dtag":"Data13TeV_SingleElectron2015BPromptReco",  "split":50, "xsec":1.0, "br":[ 1.0 ] , "dset":"/SingleElectron/Run2015B-PromptReco-v1/MINIAOD", "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_246908-251642_13TeV_PromptReco_Collisions15_JSON_v2.txt " },
+        { "dtag":"Data13TeV_SingleMuon2015BReReco", "split":50, "xsec":1.0, "br":[ 1.0 ] , "dset":"/SingleMuon/Run2015B-17Jul2015-v1/MINIAOD",       "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_246908-251642_13TeV_PromptReco_Collisions15_JSON_v2.txt " },
+        { "dtag":"Data13TeV_SingleElectron2015BReReco",  "split":50, "xsec":1.0, "br":[ 1.0 ] , "dset":"/SingleElectron/Run2015B-17Jul2015-v1/MINIAOD", "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_246908-251642_13TeV_PromptReco_Collisions15_JSON_v2.txt " },
+        { "dtag":"Data13TeV_MuonEG2015B",   "split":50, "xsec":1.0, "br":[ 1.0 ] , "dset":"/MuonEG/Run2015B-17Jul2015-v1/MINIAOD",         "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_246908-251642_13TeV_PromptReco_Collisions15_JSON_v2.txt " },
+        { "dtag":"Data13TeV_DoubleMuon2015B",   "split":50, "xsec":1.0, "br":[ 1.0 ] , "dset":"/DoubleMuon/Run2015B-17Jul2015-v1/MINIAOD",         "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_246908-251642_13TeV_PromptReco_Collisions15_JSON_v2.txt " },
+        { "dtag":"Data13TeV_DoubleEG2015B",   "split":50, "xsec":1.0, "br":[ 1.0 ] , "dset":"/DoubleEG/Run2015B-17Jul2015-v1/MINIAOD",         "lumiMask":"/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_246908-251642_13TeV_PromptReco_Collisions15_JSON_v2.txt " }
       ]             
     }    
   ]

--- a/interface/PatUtils.h
+++ b/interface/PatUtils.h
@@ -67,6 +67,11 @@ namespace patUtils
    bool passPhotonTrigger(fwlite::ChainEvent ev, float &triggerThreshold, float &triggerPrescale); 
    bool passPFJetID(std::string label, pat::Jet jet);
    bool passPUJetID(pat::Jet j);
+
+   bool passMetFilters(const fwlite::ChainEvent& ev, const bool& isPromptReco);
+   
+   bool exclusiveDataEventFilter(const double&run, const bool& isMC, const bool& isPromptReco);
+
 }
 
 #endif

--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -1,5 +1,7 @@
 #include "UserCode/llvv_fwk/interface/PatUtils.h"
 
+#include "DataFormats/METReco/interface/HcalNoiseSummary.h"
+
 namespace patUtils
 {
   bool passId(pat::Electron& el,  reco::Vertex& vtx, int IdLevel){
@@ -477,5 +479,81 @@ namespace patUtils
 
 
 
+  bool passMetFilters(const fwlite::ChainEvent& ev, const bool& isPromptReco){
+    bool passMetFilter(false);
+
+    edm::TriggerResultsByName metFilters = isPromptReco ? ev.triggerResultsByName("RECO") : ev.triggerResultsByName("PAT");
+    
+    bool CSC(     utils::passTriggerPatterns(metFilters, "Flag_CSCTightHaloFilter")); 
+    bool GoodVtx( utils::passTriggerPatterns(metFilters, "Flag_goodVertices"      ));
+    // HBHE filter needs to be complemented with , because it is messed up in data (see documentation below)
+    // bool HBHE(    utils::passTriggerPatterns(metFilters, "Flag_HBHENoiseFilter"   )); // Needs to be rerun for both data (prompt+reReco) and MC, for now.
+    // C++ conversion of the python FWLITE example: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2
+    bool HBHE(false);
+    HcalNoiseSummary summary;
+    fwlite::Handle <HcalNoiseSummary> summaryHandle;
+    summaryHandle.getByLabel(ev, "hcalnoise");
+    if(summaryHandle.isValid()) summary=*summaryHandle;
+    bool failCommon(
+                    summary.maxHPDHits() >= 17  ||
+                    summary.maxHPDNoOtherHits() >= 10 ||
+                    summary.maxZeros() >= 9e9
+                    );
+    // IgnoreTS4TS5ifJetInLowBVRegion is always false, skipping.
+    HBHE = !(failCommon || summary.HasBadRBXTS4TS5());
+    
+    if(!HBHE || !CSC || !GoodVtx) passMetFilter=false;
+    else                          passMetFilter=true;
+    
+    return passMetFilter;
+    // Documentation:    
+    // -------- Full MET filters list (see bin/chhiggs/runAnalysis.cc for details on how to print it out ------------------
+    // Flag_trackingFailureFilter
+    // Flag_goodVertices        -------> Recommended by PAG
+    // Flag_CSCTightHaloFilter  -------> Recommended by PAG
+    // Flag_trkPOGFilters
+    // Flag_trkPOG_logErrorTooManyClusters
+    // Flag_EcalDeadCellTriggerPrimitiveFilter
+    // Flag_ecalLaserCorrFilter
+    // Flag_trkPOG_manystripclus53X
+    // Flag_eeBadScFilter
+    // Flag_METFilters
+    // Flag_HBHENoiseFilter     -------> Recommended by PAG
+    // Flag_trkPOG_toomanystripclus53X
+    // Flag_hcalLaserEventFilter
+    //
+    // Notes (from https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2015#ETmiss_filters ):
+    // - For the RunIISpring15DR74 MC campaing, the process name in PAT.
+    // - For Run2015B PromptReco Data, the process name is RECO.
+    // - For Run2015B re-MiniAOD Data 17Jul2015, the process name is PAT.
+    // - MET filters are available in PromptReco since run 251585; for the earlier run range (251162-251562) use the re-MiniAOD 17Jul2015
+    // - Recommendations on how to use MET filers are given in https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2 . Note in particular that the HBHO noise filter must be re-run from MiniAOD instead of using the flag stored in the TriggerResults; this applies to all datasets (MC, PromptReco, 17Jul2015 re-MiniAOD)
+    // -------------------------------------------------
+      
+    
+  }
+
+  bool exclusiveDataEventFilter(const double& run, const bool& isMC, const bool& isPromptReco)
+  {
+    bool passExclusiveDataEventFilter(false);
+    
+    if(isMC)
+      passExclusiveDataEventFilter=true;
+    else
+      {
+        bool isForPromptReco(run<215162 || run>215562);
+        if(isPromptReco)  // Prompt reco keeps events outside of that range
+          {
+            if(isForPromptReco) passExclusiveDataEventFilter=true;
+            else                passExclusiveDataEventFilter=false;
+          }
+        else // 17Jul15 ReReco keeps event inside that range
+          {
+            if(isForPromptReco) passExclusiveDataEventFilter=false;
+            else                passExclusiveDataEventFilter=true;
+          }
+      }
+    return passExclusiveDataEventFilter;
+  }
 
 }

--- a/test/chhiggs/doAnal.sh
+++ b/test/chhiggs/doAnal.sh
@@ -24,7 +24,7 @@ if [ "${1}" = "submit" ]; then
 
 elif [ "${1}" = "lumi" ]; then 
     rm myjson.json
-    cp test/chhiggs/results_ttbar/*SingleMuon*.json > myjson.json
+    cat test/chhiggs/results_ttbar/*SingleMuon*.json > myjson.json
     echo "myjson.json has been recreated."
     echo "Now please edit myjson.json to remove the additional \"}{\" characters"
     echo "After that, please run:"


### PR DESCRIPTION
Dear All,

I followed the latest recommendations from the MET POG in order to implement the recommended MET filters in our code. 

You can find the two addional functions in PatUtils.h/cc.
You will need to use them in the way exemplified in bin/chhiggs/runAnalysis.cc.
For data, you will need to run on a mixture of PromptReco and 17Jul15 ReReco MiniAODs: one of the PatUtils functions takes care of selecting the proper orthogonal mix. My data/chhiggs/xsec_samples.json contains the paths for the PromptReco and 17Jul15 samples for a few data PDs: the full list is  https://cmsweb.cern.ch/das/request?view=plain&limit=50&instance=prod%2Fglobal&input=dataset+dataset%3D%2F*%2F*2015B*17Jul2015*%2FMINIAOD

Please let me know if you find any issue :) In the MET filter function there is some additional documentation. 

Cheers,
Pietro