### PR TITLE
Fixed the run range (typo 251->215 LoL)

### DIFF
--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -541,7 +541,7 @@ namespace patUtils
       passExclusiveDataEventFilter=true;
     else
       {
-        bool isForPromptReco(run<215162 || run>215562);
+        bool isForPromptReco(run<251162 || run>251562);
         if(isPromptReco)  // Prompt reco keeps events outside of that range
           {
             if(isForPromptReco) passExclusiveDataEventFilter=true;


### PR DESCRIPTION
Hi Loic,

sorry for the additional pull, but I had a bug in the run range selecting PromptReco vs re-MiniAOD, so this needs to be propagated before anyone runs (failing) on the samples :)

Cheers,
Pietro