### PR TITLE
Update of PF Jet ID

### DIFF
--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -496,14 +496,21 @@ namespace patUtils
     float chf( jet.chargedHadronEnergy()/rawJetEn );
     float nch    = jet.chargedMultiplicity();
     float nconst = jet.numberOfDaughters();
-    float muf( jet.muonEnergy()/rawJetEn);
+    //float muf( jet.muonEnergy()/rawJetEn);
+    float NumNeutralParticles = jet.neutralMultiplicity();
 
     //From https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID#Recommendations_for_13_TeV_data
-    if (label == "Loose") passID = ( (nhf<0.99  && nef<0.99 && nconst>1 && muf < 0.8 ) && ( fabs(jet.eta())>2.4||(fabs(jet.eta()) <= 2.4 && chf>0 && nch>0 && cef<0.99) ) );
-    if (label == "Tight") passID = ( (nhf<0.90  && nef<0.90 && nconst>1 && muf < 0.8 ) && ( fabs(jet.eta())>2.4||(fabs(jet.eta()) <= 2.4 && chf>0 && nch>0 && cef<0.90) ) );
-
+    if (label == "Loose"){
+      if( fabs(jet.eta()) <= 3.0) passID = ( (nhf<0.99  && nef<0.99 && nconst>1) && ( fabs(jet.eta())>2.4 || (fabs(jet.eta()) <= 2.4 && chf>0 && nch>0 && cef<0.99) ) );
+      if( fabs(jet.eta()) > 3.0) passID = ( nef<0.90 && NumNeutralParticles > 10);
+    }
+    if (label == "Tight"){ 
+      if( fabs(jet.eta()) <= 3.0) passID = ( (nhf<0.90  && nef<0.90 && nconst>1) && ( fabs(jet.eta())>2.4||(fabs(jet.eta()) <= 2.4 && chf>0 && nch>0 && cef<0.99) ) );
+      if( fabs(jet.eta()) > 3.0) passID = ( nef<0.90 && NumNeutralParticles > 10 );
+    }
     return passID;
   }
+
 
   bool passPUJetID(pat::Jet j){
 


### PR DESCRIPTION
This PR solves partially the problem pointed during my last talk at the 2l2nu meeting (going from 6 to 22% of events in the the VBF category for VBF samples).

As before, it follows the recommendation here : https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID#Recommendations_for_13_TeV_data 

Here was the problem : "For |eta|>3 due to the changes in PF energy fractions in the HF resulting in all jets in this area to have neutral hadron fraction of ~100%, a new set, with respect to Run I, of JetID criteria is recommended. They make use of the neutral EM fraction of jets [NEMF<0.9], and the number of neutral particles [pfjet->neutralMultiplicity()>10]. The efficiency of this new set of criteria is >=99% and the background rejection is 84% using a Minimum-Bias sample."